### PR TITLE
Edits for Ansible lab, inventory file

### DIFF
--- a/labs/02-ansible-05-home-lab-ansible/6.md
+++ b/labs/02-ansible-05-home-lab-ansible/6.md
@@ -1,60 +1,68 @@
 # Building a Basic Ansible Inventory File
 
-Ansible uses both a configuration file, which holds Ansible settings, and an Inventory file, which lists the devices being managed with related variables about those devices. On this page, you will begin to build a basic inventory file, and then add to the inventory file on the next page to prove you can run an Ansible playbook that uses a router in the DevNet Sandbox.
+Ansible uses a configuration file to store Ansible settings and an inventory file to describe the devices being managed with related variables about those devices. This section describes how to build a basic inventory file. In the next section, you add to the inventory file to prove you can run an Ansible playbook that uses a router in the DevNet Sandbox.
 
 ![alt text](/posts/files/02-ansible-05-home-lab-ansible/assets/images/desktop-5-18.png)
 
 ## Download Sample Files from GitHub
 
-This lab uses three sample Ansible files that are packaged in a [GitHub repo](http://www.github.com/WendellOdom/devnet-ansible-01). The repo holds these files:
+This lab uses three sample Ansible files that are packaged in a [GitHub repo](https://www.github.com/WendellOdom/devnet-ansible-01). The repo holds these files:
 
--   **my-inventory**: A sample inventory file
--   **test-to-sandbox.yml**: an Ansible playbook used to test Ansible with a DevNet Sandbox router.
--   **test-to-homelab.yml**: An Ansible playbook used to test Ansible with a router in your home lab.
+-   **my-inventory**: A sample inventory file.
+-   **test-to-sandbox.yml**: An Ansible playbook that tests Ansible with a DevNet Sandbox router.
+-   **test-to-homelab.yml**: An Ansible playbook that tests Ansible with a router in your home lab.
 
-Install the files into your project directory (~/AN01). If you know enough about Git to do that on your own, go ahead and do it. If not, these steps guide you through a process using as much of the GUI as possible, without a need to install Git or have a GitHub account.
+Copy the files into your project directory (~/AN01). If you know enough about Git to do that on your own, go ahead. If not, these steps guide you through a process using the GitHub UI, without requiring Git or a GitHub account.
 
-1.  On your Linux system, open Firefox (or any browser).
-2.  Open the link to the GitHub repo in the browser: [www.github.com/WendellOdom/devnet-ansible-01](http://www.github.com/WendellOdom/devnet-ansible-01)
-3.  Click the button to clone or download, and when prompted, download the repo.
+1.  On your Linux desktop, open Firefox (or any browser).
+2.  Open the link to the GitHub repo in the browser: [www.github.com/WendellOdom/devnet-ansible-01](https://www.github.com/WendellOdom/devnet-ansible-01)
+3.  Click the **Clone or download** button and then click **Download ZIP**.
 ![alt text](/posts/files/02-ansible-05-home-lab-ansible/assets/images/desktop-5-19.png)
 
-4.  After downloading the GitHub repo, take whatever steps are needed to copy the uncompressed files directly into the /AN01 project directory (and not into a subdirectory of /AN01). Feel free to use a File Manager app, or commands from the command shell. (Linux file manager apps work in concept like Windows Explorer and Mac Finder.)
-5.  Use a Linux file manager, or commands from terminal, to verify the three files shown in the next figure are in now sitting in the /AN01 the project directory.
+4.  After downloading the GitHub repo as a zip file, uncompress and copy the files directly into the /AN01 project directory (and not into a subdirectory of /AN01). You can use a file manager or commands within the command shell.
+
+5.  Use a Linux file manager or commands from terminal to verify the three files shown in the next figure are in the /AN01 project directory.
+
 ![alt text](/posts/files/02-ansible-05-home-lab-ansible/assets/images/desktop-5-20.png)
 
 ## Editing the Inventory File to Match Your Virtual Environment
 
 An Ansible inventory file can keep several important settings, primarily names and variables about each host being managed. Next, you should confirm two settings, and optionally change one of them for your own preference. The settings:
 
-**Run the ACS locally**: One setting tells Ansible to run locally, that is, that the Ansible Control Server is on this same computer.
+**Run the ACS locally**: The ACS is the Ansible Control Server. This setting tells Ansible to run locally, meaning that the Ansible Control Server is on this local computer.
 
-**Python Interpreter**: The other setting tells Ansible the directory of the Python interpreter to use.
+**Python Interpreter**: This setting tells Ansible the directory of the Python interpreter to use.
 
-1.  Move to the command shell you have been using, which should have a current directory of ~/AN01, and have the virtual environment enabled. (If those facts are not true, make it so.)
-2.  Issue the **which python** command, to list the directory from which your virtual environment would execute the **python** command.
-3.  Using any editor (for instance, on Ubuntu, gedit or vim), edit the sample inventory file (my-inventory) that is in the /AN01 project directory.
-4.  Using an editor, open the my-inventory file and look at the settings for the ansible_connection and ansible_python_interpreter.
+1.  Return to the command shell within a current directory of ~/AN01 that has the virtual environment enabled.
+2.  Issue the **which python** command, to list the directory from which your virtual environment executes the **python** command. Copy this listing for the Python Interpret setting.
+3.  Using any editor (for example, on Ubuntu, gedit or vim), edit the sample inventory file `my-inventory` in the /AN01 project directory.
+4.  Using an editor, open the `my-inventory` file and look at the `ansible_connection` and `ansible_python_interpreter` settings.
+
 ![alt text](/posts/files/02-ansible-05-home-lab-ansible/assets/images/desktop-5-21.png)
 
-   Note that the ansible_connection should remain set as “local”, so that the Ansible ACS resides on the same computer where you run your Ansible programs. You could change the setting for the Python interpreter to point to the specific filename of the Python executable in your virtual environment, as described in the next step. However, with the setting of “usr/bin/env python”, Ansible should already execute the same Python shown in that earlier **which python** command.
+> Note: The `ansible_connection` setting should remain “local” so that the Ansible ACS resides on the same computer where you run your Ansible programs. You could change the setting for the Python interpreter to point to the specific filename of the Python executable in your virtual environment, as described in the next step. However, with the setting of `usr/bin/env python`, Ansible should already execute the same Python shown in that earlier **which python** command.
 
-1.  Optionally, change the directory listed as the “ansible_python_interpreter” to match the directory in the first line of output of the **which python** command, for example:
-``ansible_python_interpreter=/home/wendellodom/AN01/venv/bin/python
-``
+5.  Optionally, change the directory listed as the “ansible_python_interpreter” to match the directory in the first line of output of the **which python** command, for example:
 
-1.  Save any changes to the my-inventory file.
+    ```
+    ansible_python_interpreter=/home/wendellodom/AN01/venv/bin/python
+    ```
+
+6.  Save any changes to the `my-inventory` file.
 
 ## Running Commands that Reference the Inventory File
 
-Ansible has a default location and name for the inventory file: /etc/ansible/hosts. However, many people use a separate inventory file, stored in a different directory. To make use of that different inventory file, you just need to reference the inventory file in the Ansible command. For this lab, you have placed that inventory file (my-inventory) into the /AC01) directory.
+Ansible has a default location and name for the inventory file: `/etc/ansible/hosts`. However, many people use a separate inventory file, stored in a different directory. To make use of a different inventory file, reference the inventory file in the Ansible command. For this lab, you copied the inventory file `my-inventory` into the ~/AC01 directory.
 
-This next task asks you to try two Ansible commands that again act locally (that is, the commands make no attempt to communicate with a networking device). The first is a repeat of the earlier Ansible ping module, and the second gathers information about the Ansible Control Server – which in this case, with the ansible_connection=local setting, is the same computer on which you issue the **ansible** command.
+This next task tries two Ansible commands that act locally (meaning, the commands make no attempt to communicate with a networking device). The first command repeats the earlier Ansible ping module, and the second command gathers information about the Ansible Control Server. In this case, with the current `ansible_connection=local` setting, the ACS is the same computer on which you issue the **ansible** command.
 
-1.  Move to the same command shell you have been using, which should have a current directory of AN01, and have the virtual environment enabled.
-2.  Repeat the **ansible -m ping localhost** command, but with a reference to the inventory file: **ansible -m ping localhost -i my-inventory**
-    -   Note that this command no longer gives the same error messages as the earlier attempt.
-    -   If the inventory file was not in the current directory, you could have referenced the entire path, for example: … **-i ./some/other/directory/my-inventory**
-    -   You should see the word “SUCCESS”, as it is pinging your computer’s loopback address.
-3.  Use the Ansible setup module to list many configuration settings for the Ansible Control Server, which is your own computer, while also listing your new inventory file: **ansible -m setup localhost -i my-inventory**
-    -   You will see a large amount of output, but if you browse through it, you should see recognizable facts, like your computer’s interfaces and IP addresses.
+1.  Return to the same command shell you have been using, which should have a current directory of ~/AN01, and have the virtual environment enabled.
+2.  Repeat the **ansible -m ping localhost** command, but with a reference to the inventory file:
+    **ansible -m ping localhost -i my-inventory**
+    -   Notice that this command no longer gives the same error messages as the earlier attempt.
+    -   If you wanted to use an inventory file not in the current directory, you can reference the entire path. For example:
+        **ansible -m ping localhost -i ./some/other/directory/my-inventory**
+    -   You should see the word “SUCCESS” when pinging your computer’s loopback address. If not, troubleshoot the network settings on the VM.
+3.  Use the Ansible setup module to list many configuration settings for the Ansible Control Server, which is your own computer, while also listing your new inventory file:
+    **ansible -m setup localhost -i my-inventory**
+    -   This command returns a large amount of output, but if you scroll through it, you can see recognizable facts like your computer’s interfaces and IP addresses.


### PR DESCRIPTION
In this PR, a Markdown convention for you to consider: use backticks surrounding file names. I can do a consistency pass for this if we think it's valuable.

```
`my-inventory`
```