### PR TITLE
Edits for Programming to Use DevNet Sandboxes and Other Devices

### DIFF
--- a/labs/02-python-01-home-lab-python/3.md
+++ b/labs/02-python-01-home-lab-python/3.md
@@ -1,31 +1,31 @@
 # Programming to Use DevNet Sandboxes and Other Devices
 
-DevNet Sandboxes are lab pods, with both real and virtual instances of various devices, available so anyone can learn and perform experiments. All you need to do is access the Sandbox, first from your web browser, and then sometimes with other tools. Some of the DevNet sandboxes are Always-On Sandboxes, which allow immediate access. Others, called Reservation Sandboxes, require prior scheduling.
+DevNet Sandboxes are lab pods with both real and virtual instances of various devices. They are made available so anyone can learn and perform experiments. All you need is to access the Sandbox from your web browser and sometimes with other tools. Some of the DevNet sandboxes are Always-On Sandboxes, which allow immediate access. Others, called Reservation Sandboxes, require prior scheduling.
 
 ![alt text](/posts/files/02-python-01-home-lab-python/assets/images/desktop-1-06.png)
 
-At some point, you may want to do all your work using gear that sits in your own home lab. However, the idea of using tools on your own computer, along with a DevNet Sandbox, gives you a very useful interim step for learning about several topics. This page of the lab looks at a few of those options.
+You may want to do all your work using gear that sits in your own home lab. However, the idea of using tools on your own computer, along with a DevNet Sandbox, gives you a very useful interim step for learning about several topics. This page of the lab looks at a few of those options.
 
 ## APIC-EM
 
-One of the best APIs for networkers to use when learning about programming and APIs is the APIC-EM API. Why? First, the data supplied by the API is all about the networking devices, so the data should be somewhat familiar. Second, Cisco DevNet gives us several Sandboxes to use to experience APIC-EM, along with several Learning Labs. Finally, APIC-EM software is free, so you can even install it in your home lab if you have enough server hardware/capacity to run it.
+One of the best APIs for learning about programming and APIs is the APIC-EM API. Why? First, the data supplied by the API is about networking devices, so the data should be familiar. Second, Cisco DevNet provides several Sandboxes to use with APIC-EM, along with several Learning Labs. Third, APIC-EM software is free, so you can install it in your home lab if you have enough server hardware/capacity to run it.
 
-(Note that the entire first module of the “[Build Your Home Network for Network Programmability](https://learninglabs.cisco.com/modules?keywords=home)” Learning Track is devoted to the topic of APIC-EM, the decision of whether to install it at home, and the major steps to work through to install it in your home lab.)
+Note that the entire first module of the “[Build Your Home Network for Network Programmability](https://learninglabs.cisco.com/modules/home-lab-network)” Learning Track is devoted to the topic of APIC-EM, the decision of whether to install it at home, and the major steps to work through to install it in your home lab.
 
-To write Python code that calls the APIC-EM API, or even to use REST clients like Postman to learn about the APIC-EM API, you need access to a working instance of APIC-EM. Here are your three primary options:
+To write Python code or to use REST clients like Postman to call the APIC-EM API, you need access to a working instance of APIC-EM. Here are your three options:
 
-**The DevNet Always-on APIC-EM Sandbox**: The [Always-on APIC-EM Sandbox](https://devnetsandbox.cisco.com/RM/Topology?c=14ec7ccf-2988-474e-a135-1e90b9bc6caf) has a working APIC-EM that is waiting for you to make API calls, always-on, no need to reserve the lab pod, and no need to wait until the lab pod is initialized.
+**The DevNet Always-on APIC-EM Sandbox**: The [Always-on APIC-EM Sandbox](https://devnetsandbox.cisco.com/RM/Topology?c=14ec7ccf-2988-474e-a135-1e90b9bc6caf) has a working APIC-EM that is waiting for you to make API calls with no need to reserve the lab pod and no need to wait for initialization.
 
-**The DevNet Reservable APIC-EM Sandboxes**: These [reservable APIC-EM Sandboxes](https://devnetsandbox.cisco.com/RM/Topology?c=14ec7ccf-2988-474e-a135-1e90b9bc6caf) (with varied networking devices and topologies) all have a working APIC-EM. You must reserve the lab, and if you use it immediately, you will need to wait for the lab pod to be initialized.
+**The DevNet Reservable APIC-EM Sandboxes**: These [reservable APIC-EM Sandboxes](https://devnetsandbox.cisco.com/RM/Topology?c=14ec7ccf-2988-474e-a135-1e90b9bc6caf) (with varied networking devices and topologies) all have a working APIC-EM. You must reserve the lab and then wait for the lab pod to be initialized.
 
-**Your own APIC-EM Instance**: Install APIC-EM in your home lab, and use it to manage your own lab networking gear. Read more about this option in the Module “[Adding APIC-EM to Your Home Lab](https://learninglabs.cisco.com/modules?keywords=home)”.
+**Your own APIC-EM Instance**: Install APIC-EM in your home lab, and use it to manage your home lab networking gear. Read more about this option in the Module “[Adding APIC-EM to Your Home Lab](https://learninglabs.cisco.com/modules/home-lab-network)”.
 
 ![alt text](/posts/files/02-python-01-home-lab-python/assets/images/desktop-1-07.png)
 
 ## Cisco Spark
 
-Cisco Spark is a cloud-based service that provides a variety of collaboration tools, including messaging. Because it has an API, you can use Spark as a means to communicate with others regarding what your network programs do or sense. Even if you are learning on your own, without others to collaborate with, using the Spark API can be both useful for learning and useful when creating your own networking projects.
+Cisco Spark is a cloud-based service that provides a variety of collaboration tools, including messaging. Because it has an API, you can use Spark as a means to communicate with others about your network programs. Even if you are learning on your own, without others to collaborate with, using the Spark API can be both useful for learning and useful when creating your own networking projects.
 
 Note that you would not need a DevNet sandbox or even your own device to experiment with in this case. Spark runs as a cloud-based service, that is, the API calls are made against a service that is already running for normal users. Look to the third lab in this [DevNet Learning Module](https://learninglabs.cisco.com/modules/home-lab-desktop)DevNet Learning Module (“Home Lab: Setting up Postman and Other Programming Tools”) for more detail about Spark and accessing the Spark API.
 
-Now that you know about some of the key DevNet resources, the rest of this lab focuses on Python, and how to make it work on your computer.
+Now that you know about key DevNet resources, the rest of this lab focuses on Python, and how to make it work on your computer.


### PR DESCRIPTION
With the social login, the link for a search for `?home` in the url was not going to work, so I directly linked to the home-lab-network URL. Let me know if that changes the intent for the links; if so we can find another way to link.