### PR TITLE
Edits for Understanding Python Modules

### DIFF
--- a/labs/02-pip-ve-02-home-lab-pip-virtual-environment/2.md
+++ b/labs/02-pip-ve-02-home-lab-pip-virtual-environment/2.md
@@ -1,14 +1,14 @@
-# Understanding Python Modules and the Need for PIP
+# Understanding Python Modules
 
-When anyone writes code today, much of what they want to accomplish can be done with existing features and modules rather than writing lots of new code. To that end, the Python interpreter installation package includes a number of these modules, but many more modules are available for download and use in your Python program. This page examines the topic of Python modules, how to import them into your program, and how to get them onto your computer to make them available to your program.
+When writing code today, much can be done with existing features and modules rather than writing new code. To that end, the Python interpreter installation package includes a number of these modules, but you can download and use more modules in your Python program. This page examines the topic of Python modules, how to import them in your program, and how to make them available to your program.
 
 ## The Python Standard Library
 
-When you install the Python interpreter, the software process adds the [Python Standard Library](https://docs.python.org/3/library/index.html) to your computer. The word *Library* refers to a collection of code and features implemented in a variety of files. Basically, the Python Standard Library defines some standard features you have available in Python, some of which happen to be implemented in Python programs themselves, *without your needing to download anything else to your computer*.
+When you install the Python interpreter, the software process adds the [Python Standard Library](https://docs.python.org/3/library/index.html) to your computer. The word *Library* refers to a collection of code and features implemented in a variety of files. Basically, the Python Standard Library defines some standard features you have available in Python, some of which happen to be implemented in Python programs themselves, *without needing to download anything else to your computer*.
 
-The Python Standard Library can be viewed as having two major branches: built-in features and optional modules. First, the built-in features are obvious by their name, but less obvious in that you do not need to do anything special to use them. For instance, the **print()** function is a built-in function of the Python Standard Library; you can just add it to your program and use it.
+You can think about the Python Standard Library providing two major branches: built-in features and optional modules. First, the mechanism for using built-in features seems obvious by their name, and you do not need to do anything special to use them. For instance, the **print()** function is a built-in function of the Python Standard Library; you can just add it to your program and use it.
 
-The Python Standard Library also includes many optional modules. However, unlike the built-in features, the interpreter does not make these optional modules available to your program until you ask for them. Instead, the program must use the **import** statement, for instance, for example, **import sys**. (The **sys** module is one of the optional modules included in the Python Standard Library.)
+The Python Standard Library also includes many optional modules. However, unlike the built-in features, you must indicate to the interpreter that you want these optional modules available to your program. Your program must use the **import** statement, for example, **import sys**, where the **sys** module is an optional module in the Python Standard Library.
 
 ![alt text](/posts/files/02-pip-ve-02-home-lab-pip-virtual-environment/assets/images/desktop-2-02.png)
 
@@ -16,15 +16,15 @@ The Python Standard Library also includes many optional modules. However, unlike
 
 To see the differences between built-in functions and optional modules, take a moment to search through the [Python documentation](https://docs.python.org/3/library/index.html) for two functions: **print** and **pprint**. Or just click directly to each with these links:
 
-[print()](https://docs.python.org/3/library/index.html) – Built-in Function  
+[print()](https://docs.python.org/3/library/index.html) – Built-in Function
 [pprint()](https://docs.python.org/3/library/pprint.html) – Optional Module
 
 Comparing these two, **print()** acts as the most common standard method to print text to the screen, and does not require an **import print** statement. Pretty Print (pprint), as an optional module, should already be installed on your system, but requires an **import pprint** (or similar) statement before a program can use it. This next exercise shows the difference.
 
-To begin, we need something to print, preferably something that also shows the benefit of using pprint instead of print. To do so:
+To begin, we need something to print that also shows the benefit of using **pprint** instead of **print**. To do so:
 
-1.  Open a command prompt/shell
-2.  Start a Python 2.7 or 3.x interactive session
+1.  Open a command prompt/shell.
+2.  Start a Python 2.7 or 3.x interactive session.
 3.  Copy and paste the dictionary in the code sample below to create a dictionary variable to work with.
 4.  Type **netdict** (the name of the variable that was just set), which tells the interpreter to display the contents of the variable.
 
@@ -64,4 +64,4 @@ You should have seen these results:
 
 ## Extra Exercise
 
-Extra Exercise: Go to the [Python Standard Library](https://docs.python.org/3/library/index.html) doc page, and look at the modules listed there. Then try to import some of them by name. For instance, search for the **sys** module imported with the **import sys** command earlier in this DevNet Learning Lab.
+Go to the [Python Standard Library](https://docs.python.org/3/library/index.html) doc page, and look at the modules listed there. Try to import some of them by name. For instance, search for the **sys** module imported with the **import sys** command earlier in this DevNet Learning Lab.


### PR DESCRIPTION
Perhaps I missed it, but I never saw the need for pip described in this topic. If it's there, then definitely spell out the acronym PIP at first use (realizing there are two possibilites, Pip Installs Python or PIP Installs Packages).